### PR TITLE
migrate localbroadcastmanager to androidx

### DIFF
--- a/android/src/main/kotlin/com/pycampers/flutterpdfviewer/FlutterPdfViewerPlugin.kt
+++ b/android/src/main/kotlin/com/pycampers/flutterpdfviewer/FlutterPdfViewerPlugin.kt
@@ -5,7 +5,7 @@ import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
 import android.os.Bundle
-import android.support.v4.content.LocalBroadcastManager
+import androidx.localbroadcastmanager.content.LocalBroadcastManager
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler


### PR DESCRIPTION
change android.support.v4.content.LocalBroadcastManager to androidx.localbroadcastmanager.content.LocalBroadcastManager as a part of the migration to androidx